### PR TITLE
Notify ferm about config instead of restarting

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -121,13 +121,7 @@
     owner: 'root'
     group: 'adm'
     mode: '0644'
-  register: postfix_register_ferm_rules
-
-- name: Restart ferm if firewall rules change
-  service:
-    name: 'ferm'
-    state: 'restarted'
-  when: postfix_register_ferm_rules.changed
+  notify: [ 'Restart ferm' ]
 
 - name: Restart Postfix if capabilities change
   template:


### PR DESCRIPTION
This is done so that 'debops.postfix' can work correctly in environments
where firewall management is disabled in 'debops.ferm'.