### PR TITLE
Properly cleanup Cyrus-SASL config

### DIFF
--- a/tasks/cleanup_sasl_cyrus.yml
+++ b/tasks/cleanup_sasl_cyrus.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Remove unwanted files if Cyrus-SASL is disabled
+  file:
+    path: '/etc/default/saslauthd-smtpd'
+    state: 'absent'
+  notify: [ 'Restart saslauthd' ]

--- a/tasks/disable_revert.yml
+++ b/tasks/disable_revert.yml
@@ -29,3 +29,4 @@
   command: dpkg-divert --quiet --local --rename --remove /etc/aliases
            removes=/etc/aliases.dpkg-divert
 
+- include: cleanup_sasl_cyrus.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,10 @@
   when: ((postfix is defined and postfix) and
          ('auth' in postfix and postfix_smtpd_sasl_type == 'cyrus'))
 
+- include: cleanup_sasl_cyrus.yml
+  when: ((postfix is defined and postfix) and
+         ('auth' not in postfix or postfix_smtpd_sasl_type != 'cyrus'))
+
 - include: disable_revert.yml
   when: not postfix
 


### PR DESCRIPTION
Cleanup `/etc/default/saslauthd-smtpd` if Cyrus authentication is disabled or postfix is removed.