### PR TITLE
Changing tabulators to whitespaces.

### DIFF
--- a/templates/etc/postfix/main.cf/basic_options.j2
+++ b/templates/etc/postfix/main.cf/basic_options.j2
@@ -1,31 +1,31 @@
 {% import 'macros.j2' as get with context %}
 # Base options
-smtpd_banner			= {{ postfix_smtpd_banner | default('$myhostname ESMTP $mail_name') }}
-biff				= no
-append_dot_mydomain		= no
-delay_warning_time		= {{ postfix_delay_warning_time | default('4h') }}
-enable_long_queue_ids		= {{ postfix_long_queue_ids | default('yes') }}
+smtpd_banner                    = {{ postfix_smtpd_banner | default('$myhostname ESMTP $mail_name') }}
+biff                            = no
+append_dot_mydomain             = no
+delay_warning_time              = {{ postfix_delay_warning_time | default('4h') }}
+enable_long_queue_ids           = {{ postfix_long_queue_ids | default('yes') }}
 
 {% if 'local' in postfix %}
-myorigin			= /etc/mailname
+myorigin                        = /etc/mailname
 {% else %}
 {% if ((postfix_mydomain is defined and postfix_mydomain) or (ansible_domain is defined and ansible_domain)) %}
-myorigin			= $mydomain
+myorigin                        = $mydomain
 {% else %}
-myorigin			= $myhostname
+myorigin                        = $myhostname
 {% endif %}
-local_recipient_maps		=
-local_transport			= error:local mail delivery is disabled
+local_recipient_maps            =
+local_transport                 = error:local mail delivery is disabled
 
 {% endif %}
-myhostname			= {{ postfix_myhostname | default(ansible_fqdn) }}
+myhostname                      = {{ postfix_myhostname | default(ansible_fqdn) }}
 {% if ((postfix_mydomain is defined and postfix_mydomain) or (ansible_domain is defined and ansible_domain)) %}
-mydomain			= {{ postfix_mydomain | default(ansible_domain) }}
+mydomain                        = {{ postfix_mydomain | default(ansible_domain) }}
 {% endif %}
-smtp_helo_name			= {{ postfix_smtp_helo_name | default(ansible_fqdn) }}
+smtp_helo_name                  = {{ postfix_smtp_helo_name | default(ansible_fqdn) }}
 
 alias_maps                      = {{ get.list('alias_maps', [ 'hash:/etc/aliases' ]) }}
-alias_database			= hash:/etc/aliases
+alias_database                  = hash:/etc/aliases
 {% set postfix_tpl_virtual_alias_maps = [] %}
 {% if ('mx' in postfix or 'submission' in postfix) and 'local' not in postfix %}
 {% set postfix_tpl_virtual_alias_maps = postfix_tpl_virtual_alias_maps + ['hash:${config_directory}/hash_tables/mx_relay_virtual_alias_maps'] %}
@@ -34,17 +34,17 @@ alias_database			= hash:/etc/aliases
 virtual_alias_maps              = {{ get.list('virtual_alias_maps', postfix_tpl_virtual_alias_maps + postfix_virtual_alias_maps) }}
 {% endif %}
 
-mailbox_size_limit		= {{ postfix_mailbox_size_limit | default('0') }}
-message_size_limit		= {{ (postfix_message_size_limit | default(50) * 1024 * 1024|int)|round|int|string }}
-recipient_delimiter		= {{ postfix_recipient_delimiter | default('+') }}
+mailbox_size_limit              = {{ postfix_mailbox_size_limit | default('0') }}
+message_size_limit              = {{ (postfix_message_size_limit | default(50) * 1024 * 1024|int)|round|int|string }}
+recipient_delimiter             = {{ postfix_recipient_delimiter | default('+') }}
 {% if 'network' in postfix %}
 {% if postfix_inet_interfaces is defined and postfix_inet_interfaces %}
-inet_interfaces			= {{ postfix_inet_interfaces }}
+inet_interfaces                 = {{ postfix_inet_interfaces }}
 {% else %}
-inet_interfaces			= all
+inet_interfaces                 = all
 {% endif %}
 {% else %}
-inet_interfaces			= loopback-only
+inet_interfaces                 = loopback-only
 {% endif %}
 
 {% set postfix_tpl_mydestination = [] %}
@@ -58,11 +58,11 @@ inet_interfaces			= loopback-only
 {% set postfix_tpl_mydestination = postfix_mydestination %}
 {% endif %}
 {% if postfix_tpl_mydestination %}
-mydestination			= {{ ', '.join(postfix_tpl_mydestination | unique) }}
+mydestination                   = {{ ', '.join(postfix_tpl_mydestination | unique) }}
 {% else %}
-mydestination			=
+mydestination                   =
 {% endif %}
-mynetworks			= {{ ', '.join((postfix_mynetworks + ['127.0.0.0/8','::ffff:127.0.0.0/104', '::1/128']) | ipwrap) }}
+mynetworks                      = {{ ', '.join((postfix_mynetworks + ['127.0.0.0/8','::ffff:127.0.0.0/104', '::1/128']) | ipwrap) }}
 
 {% if get.list('virtual_alias_domains') %}
 virtual_alias_domains           = {{ get.list('virtual_alias_domains') }}
@@ -82,21 +82,21 @@ relay_domains                   = {{ get.list('relay_domains', postfix_tpl_relay
 {% endif %}
 {% if get.list('relay_recipient_maps', postfix_tpl_relay_recipient_maps) %}
 relay_recipient_maps            = {{ get.list('relay_recipient_maps', postfix_tpl_relay_recipient_maps) }}
-show_user_unknown_table_name	= no
+show_user_unknown_table_name    = no
 {% endif %}
 {% if postfix_relayhost is defined and postfix_relayhost %}
 {% if postfix_relayhost == True %}
-relayhost			= {{ ansible_domain }}
+relayhost                       = {{ ansible_domain }}
 
 {% else %}
 {% if postfix_relayhost != ansible_fqdn %}
-relayhost			= {{ postfix_relayhost }}
+relayhost                       = {{ postfix_relayhost }}
 
 {% endif %}
 {% endif %}
 {% elif 'local' not in postfix and 'mx' not in postfix %}
 {% if ansible_domain is defined and ansible_domain %}
-relayhost			= {{ ansible_domain }}
+relayhost                       = {{ ansible_domain }}
 {% endif %}
 
 {% endif %}
@@ -117,15 +117,15 @@ transport_maps                  = {{ get.list('transport_maps', postfix_tpl_tran
 {% if 'mx' in postfix %}
 parent_domain_matches_subdomains = debug_peer_list, smtpd_access_maps
 {% endif %}
-disable_vrfy_command		= {{ postfix_disable_vrfy_command | default('yes') }}
-strict_rfc821_envelopes		= {{ postfix_strict_rfc821_envelopes | default('yes') }}
-smtpd_helo_required		= {{ postfix_smtpd_helo_required | default('yes') }}
-smtpd_reject_unlisted_sender	= {{ postfix_smtpd_reject_unlisted_sender | default('yes') }}
+disable_vrfy_command            = {{ postfix_disable_vrfy_command | default('yes') }}
+strict_rfc821_envelopes         = {{ postfix_strict_rfc821_envelopes | default('yes') }}
+smtpd_helo_required             = {{ postfix_smtpd_helo_required | default('yes') }}
+smtpd_reject_unlisted_sender    = {{ postfix_smtpd_reject_unlisted_sender | default('yes') }}
 {% if 'test' in postfix or 'defer' in postfix or (postfix_soft_bounce is defined and postfix_soft_bounce) %}
-soft_bounce			= {{ postfix_soft_bounce | default('yes') }}
+soft_bounce                     = {{ postfix_soft_bounce | default('yes') }}
 
 {% endif %}
 {% if 'test' in postfix and postfix_smtpd_authorized_xclient_hosts is defined and postfix_smtpd_authorized_xclient_hosts %}
-smtpd_authorized_xclient_hosts	= {{ ', '.join(postfix_smtpd_authorized_xclient_hosts) }}
+smtpd_authorized_xclient_hosts  = {{ ', '.join(postfix_smtpd_authorized_xclient_hosts) }}
 {% endif %}
 

--- a/templates/etc/postfix/main.cf/postscreen.j2
+++ b/templates/etc/postfix/main.cf/postscreen.j2
@@ -1,8 +1,8 @@
 {% if ('!postscreen' not in postfix and ('postscreen' in postfix or 'mx' in postfix)) %}
 # postscreen configuration (http://rob0.nodns4.us/postscreen.html)
-postscreen_blacklist_action    = {{ postfix_postscreen_blacklist_action | default('drop') }}
-postscreen_greet_action        = {{ postfix_postscreen_greet_action | default('enforce') }}
-postscreen_dnsbl_action        = {{ postfix_postscreen_dnsbl_action | default('enforce') }}
+postscreen_blacklist_action     = {{ postfix_postscreen_blacklist_action | default('drop') }}
+postscreen_greet_action         = {{ postfix_postscreen_greet_action | default('enforce') }}
+postscreen_dnsbl_action         = {{ postfix_postscreen_dnsbl_action | default('enforce') }}
 
 postscreen_access_list =
 {% if postfix_postscreen_access_list is defined and postfix_postscreen_access_list %}
@@ -37,7 +37,7 @@ postscreen_dnsbl_reply_map =
 {{ ",\n".join(postfix_tpl_postscreen_dnsbl_reply_map) | indent(6,true) }}
 {% endif %}
 
-postscreen_dnsbl_threshold     = {{ postfix_postscreen_dnsbl_threshold | default('3') }}
+postscreen_dnsbl_threshold      = {{ postfix_postscreen_dnsbl_threshold | default('3') }}
 {% else %}
       # required postfix capability: +dnsbl|+dnswl
 {% endif %}
@@ -45,14 +45,14 @@ postscreen_dnsbl_threshold     = {{ postfix_postscreen_dnsbl_threshold | default
 postscreen_whitelist_interfaces = static:all
 
 # postscreen greylisting actions
-postscreen_pipelining_enable   = {{ postfix_postscreen_pipelining_enable | default('yes') }}
-postscreen_pipelining_action   = {{ postfix_postscreen_pipelining_action | default('enforce') }}
+postscreen_pipelining_enable    = {{ postfix_postscreen_pipelining_enable | default('yes') }}
+postscreen_pipelining_action    = {{ postfix_postscreen_pipelining_action | default('enforce') }}
 
 postscreen_non_smtp_command_enable = {{ postfix_postscreen_non_smtp_command_enable | default('yes') }}
 postscreen_non_smtp_command_action = {{ postfix_postscreen_non_smtp_command_action | default('drop') }}
 
-postscreen_bare_newline_enable = {{ postfix_postscreen_bare_newline_enable | default('yes') }}
-postscreen_bare_newline_action = {{ postfix_postscreen_bare_newline_action | default('ignore') }}
+postscreen_bare_newline_enable  = {{ postfix_postscreen_bare_newline_enable | default('yes') }}
+postscreen_bare_newline_action  = {{ postfix_postscreen_bare_newline_action | default('ignore') }}
 {% else %}
 # postscreen disabled, required capabilities: +mx|+postscreen
 {% endif %}

--- a/templates/etc/postfix/main.cf/sasl_auth.j2
+++ b/templates/etc/postfix/main.cf/sasl_auth.j2
@@ -1,12 +1,12 @@
 {% if 'auth' in postfix %}
 
 # SASL authentication
-smtpd_sasl_type				= {{ postfix_smtpd_sasl_type | default('cyrus') }}
-smtpd_sasl_path				= {{ postfix_smtpd_sasl_path[postfix_smtpd_sasl_type] }}
+smtpd_sasl_type                 = {{ postfix_smtpd_sasl_type | default('cyrus') }}
+smtpd_sasl_path                 = {{ postfix_smtpd_sasl_path[postfix_smtpd_sasl_type] }}
 
-smtpd_sasl_auth_enable			= yes
-broken_sasl_auth_clients		= yes
-smtpd_sasl_security_options		= noanonymous
+smtpd_sasl_auth_enable          = yes
+broken_sasl_auth_clients        = yes
+smtpd_sasl_security_options     = noanonymous
 {% endif %}
 
 

--- a/templates/etc/postfix/main.cf/tls.j2
+++ b/templates/etc/postfix/main.cf/tls.j2
@@ -4,31 +4,31 @@
 {% set postfix_tpl_tls_key_file          = postfix_pki_path + "/" + postfix_pki_realm + "/" + postfix_pki_key %}
 {% set postfix_tpl_tls_dh512_param_file  = postfix_pki_path + "/" + postfix_pki_realm + "/dhparams/dh512.pem" %}
 {% set postfix_tpl_tls_dh1024_param_file = postfix_pki_path + "/" + postfix_pki_realm + "/" + postfix_pki_dhparam %}
-smtpd_tls_cert_file		= {{ postfix_tpl_tls_cert_file }}
-smtpd_tls_key_file		= {{ postfix_tpl_tls_key_file }}
-smtpd_tls_dh1024_param_file	= {{ postfix_tpl_tls_dh1024_param_file }}
-smtpd_tls_dh512_param_file	= {{ postfix_tpl_tls_dh512_param_file }}
+smtpd_tls_cert_file             = {{ postfix_tpl_tls_cert_file }}
+smtpd_tls_key_file              = {{ postfix_tpl_tls_key_file }}
+smtpd_tls_dh1024_param_file     = {{ postfix_tpl_tls_dh1024_param_file }}
+smtpd_tls_dh512_param_file      = {{ postfix_tpl_tls_dh512_param_file }}
 
 {% endif %}
-tls_high_cipherlist		= !aNULL:ALL:!EXPORT:!LOW:!MEDIUM:!DES:!3DES:!MD5:!RC4:@STRENGTH
-tls_medium_cipherlist		= !aNULL:ALL:!EXPORT:!LOW:!DES:!3DES:!MD5:!RC4:@STRENGTH
-tls_low_cipherlist		= !aNULL:ALL:!EXPORT:!DES:!3DES:!MD5:!RC4:@STRENGTH
+tls_high_cipherlist             = !aNULL:ALL:!EXPORT:!LOW:!MEDIUM:!DES:!3DES:!MD5:!RC4:@STRENGTH
+tls_medium_cipherlist           = !aNULL:ALL:!EXPORT:!LOW:!DES:!3DES:!MD5:!RC4:@STRENGTH
+tls_low_cipherlist              = !aNULL:ALL:!EXPORT:!DES:!3DES:!MD5:!RC4:@STRENGTH
 
-smtpd_tls_auth_only		= yes
-smtpd_tls_received_header	= yes
-smtpd_tls_security_level	= {{ postfix_smtpd_tls_security_level | default('may') }}
-smtpd_tls_ciphers		= {{ postfix_smtpd_tls_ciphers | default('medium') }}
-smtpd_tls_exclude_ciphers	= aNULL, DES, 3DES, MD5, DES+MD5, RC4
-smtpd_tls_protocols		= !SSLv2, !SSLv3, TLSv1, TLSv1.1, TLSv1.2
+smtpd_tls_auth_only             = yes
+smtpd_tls_received_header       = yes
+smtpd_tls_security_level        = {{ postfix_smtpd_tls_security_level | default('may') }}
+smtpd_tls_ciphers               = {{ postfix_smtpd_tls_ciphers | default('medium') }}
+smtpd_tls_exclude_ciphers       = aNULL, DES, 3DES, MD5, DES+MD5, RC4
+smtpd_tls_protocols             = !SSLv2, !SSLv3, TLSv1, TLSv1.1, TLSv1.2
 
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-smtp_tls_note_starttls_offer	= yes
-smtp_tls_security_level		= {{ postfix_smtp_tls_security_level | default('may') }}
-smtp_tls_ciphers		= {{ postfix_smtp_tls_ciphers | default('high') }}
-smtp_tls_exclude_ciphers	= aNULL, DES, 3DES, MD5, DES+MD5, RC4
-smtp_tls_protocols		= !SSLv2, !SSLv3, TLSv1, TLSv1.1, TLSv1.2
-smtp_tls_CApath			= /etc/ssl/certs
+smtp_tls_note_starttls_offer    = yes
+smtp_tls_security_level         = {{ postfix_smtp_tls_security_level | default('may') }}
+smtp_tls_ciphers                = {{ postfix_smtp_tls_ciphers | default('high') }}
+smtp_tls_exclude_ciphers        = aNULL, DES, 3DES, MD5, DES+MD5, RC4
+smtp_tls_protocols              = !SSLv2, !SSLv3, TLSv1, TLSv1.1, TLSv1.2
+smtp_tls_CApath                 = /etc/ssl/certs
 
 


### PR DESCRIPTION
I changed a lot of tabulators to whitespaces in the postfix/main.cf. So now the indention of the = is on the same column over the whole main.cf.