### PR TITLE
Changed notification to `Restart postfix`

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -57,7 +57,7 @@
     group: 'root'
     mode: '0644'
   with_items: [ 'main.cf', 'master.cf' ]
-  notify: [ 'Check postfix', 'Reload postfix' ]
+  notify: [ 'Check postfix', 'Restart postfix' ]
 
 - name: Generate Postfix tables sources
   template:


### PR DESCRIPTION
`Restart postfix` is used everywhere else. The `Reload postfix` handler also doesn't reload the service. It still restarts it which makes the two identical.