### PR TITLE
Added make package as dependency

### DIFF
--- a/tasks/install_divert.yml
+++ b/tasks/install_divert.yml
@@ -6,7 +6,7 @@
     state: 'latest'
     install_recommends: False
   with_items:
-    - [ 'postfix', 'postfix-pcre', 'bsd-mailx' ]
+    - [ 'postfix', 'postfix-pcre', 'bsd-mailx', 'make' ]
     - '{{ postfix_packages }}'
   when: item is defined and item
 


### PR DESCRIPTION
`make` is required to configure postfix but isn't installed by this role so this PR fixes that. 