### PR TITLE
put smtp inet in master.cf in !postscreen is set

### DIFF
--- a/templates/etc/postfix/master.cf/smtp.j2
+++ b/templates/etc/postfix/master.cf/smtp.j2
@@ -1,4 +1,4 @@
-{% if 'mx' in postfix or 'postscreen' in postfix %}
+{% if ( 'mx' in postfix or 'postscreen' in postfix ) and '!postscreen' not in postfix %}
 smtpd     pass  -       -       -       -       -       smtpd
 {% else %}
 smtp      inet  n       -       -       -       -       smtpd


### PR DESCRIPTION
I use mx and !postscreen parameter and want my stmp listen on the unix socket; this is the right use case or I missed something ?