### PR TITLE
generic sasl auth

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -359,26 +359,26 @@ postfix_postscreen_dnswl_sites:
 # .. envvar:: postfix_smtpd_sasl_type
 #
 # The SASL plug-in type that the Postfix SMTP server should use for
-# authentication (currently supported: ``cyrus``).
+# authentication (currently supported: ``cyrus`` and ``dovecot``).
 postfix_smtpd_sasl_type: 'cyrus'
 
 
-# .. envvar:: postfix_cyrus_smtpd_conf:
+# .. envvar:: postfix_smtpd_conf:
 #
-# Configuration for Cyrus SASL authentication plugin, in text block format.
-# See `Postfix SASL README <http://www.postfix.org/SASL_README.html>`_ for more
-# details.
-postfix_cyrus_smtpd_conf: |
+# Configuration for Cyrus and Dovecot SASL authentication plugin, in text block
+# format.  See `Postfix SASL README <http://www.postfix.org/SASL_README.html>`_
+# for more details.
+postfix_smtpd_conf: |
   pwcheck_method: saslauthd
   mech_list: PLAIN LOGIN
 
 
-# .. envvar:: postfix_cyrus_saslauthd_options
+# .. envvar:: postfix_saslauthd_options
 #
 # Configuration parameters passed to the :program:`saslauthd` daemon. Path to
 # the UNIX socket is added automatically. See :manpage:`saslauthd(8)` for more
 # details.
-postfix_cyrus_saslauthd_options: '-c'
+postfix_saslauthd_options: '-c'
 
 
 # ------------------------------

--- a/tasks/auth_sasl.yml
+++ b/tasks/auth_sasl.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install Cyrus SASL if enabled
+- name: Install SASL if enabled
   apt:
     name: '{{ item }}'
     state: 'present'

--- a/tasks/cleanup_sasl.yml
+++ b/tasks/cleanup_sasl.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Remove unwanted files if Cyrus-SASL is disabled
+- name: Remove unwanted files if SASL is disabled
   file:
     path: '/etc/default/saslauthd-smtpd'
     state: 'absent'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,13 +30,15 @@
 - include: configure.yml
   when: postfix
 
-- include: auth_sasl_cyrus.yml
+- include: auth_sasl.yml
   when: ((postfix is defined and postfix) and
-         ('auth' in postfix and postfix_smtpd_sasl_type == 'cyrus'))
+         ('auth' in postfix and ( postfix_smtpd_sasl_type == 'cyrus' 
+          or postfix_smtpd_sasl_type == 'dovecot')))
 
-- include: cleanup_sasl_cyrus.yml
+- include: cleanup_sasl.yml
   when: ((postfix is defined and postfix) and
-         ('auth' not in postfix or postfix_smtpd_sasl_type != 'cyrus'))
+         ('auth' not in postfix or ( postfix_smtpd_sasl_type != 'cyrus' 
+          and postfix_smtpd_sasl_type != 'dovecot')))
 
 - include: disable_revert.yml
   when: not postfix

--- a/templates/etc/default/saslauthd-smtpd.j2
+++ b/templates/etc/default/saslauthd-smtpd.j2
@@ -60,4 +60,4 @@ THREADS=5
 # then your Postfix is running in a chroot.
 # If it has the line "smtp inet n - n - - smtpd" then your Postfix is NOT
 # running in a chroot. #}
-OPTIONS="{{ postfix_cyrus_saslauthd_options }} -m /var/spool/postfix/var/run/saslauthd"
+OPTIONS="{{ postfix_saslauthd_options }} -m /var/spool/postfix/var/run/saslauthd"

--- a/templates/etc/postfix/sasl/smtpd.conf.j2
+++ b/templates/etc/postfix/sasl/smtpd.conf.j2
@@ -1,4 +1,4 @@
 # This file is managed by Ansible, all changes will be lost
 
-{{ postfix_cyrus_smtpd_conf }}
+{{ postfix_smtpd_conf }}
 


### PR DESCRIPTION
SASL method used for cyrus authentication is the same for dovecot SASL authentication. This PR just rename some variable to be a little bit more generic.