### PR TITLE
add rspamd spam filtering system

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -513,6 +513,19 @@ postfix_dependent_mastercf: []
 # extension when ``test`` Postfix capability is enabled.
 postfix_smtpd_authorized_xclient_hosts: [ '127.0.0.1/32' ]
 
+# -------------------------------
+#   Rspamd/Rmilter options
+# -------------------------------
+
+# .. envvar:: rspamd_packages 
+#
+# List of packages to be installed with rspamd
+rspamd_packages: [ 'rspamd', 'rmilter', 'memcached' ]
+
+# .. envvar:: postfix_rmilter_com 
+#
+# How rmilter shoult listen 
+postfix_rmilter_bind: 'inet'
 
 # ----------------------------------
 #   External service configuration

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,3 +20,10 @@
   service:
     name: 'saslauthd'
     state: 'restarted'
+
+# handlers file for rspamd
+- name: Restart rmilter
+  service:
+    name: 'rmilter'
+    state: 'restarted'
+

--- a/tasks/disable_revert.yml
+++ b/tasks/disable_revert.yml
@@ -29,4 +29,4 @@
   args:
     removes: '/etc/aliases.dpkg-divert'
 
-- include: cleanup_sasl_cyrus.yml
+- include: cleanup_sasl.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,10 @@
 - include: configure.yml
   when: postfix
 
+- include: rspamd.yml
+  when: ((postfix is defined and postfix) and
+         ('rspamd' in postfix ))
+
 - include: auth_sasl.yml
   when: ((postfix is defined and postfix) and
          ('auth' in postfix and ( postfix_smtpd_sasl_type == 'cyrus' 

--- a/tasks/rspamd.yml
+++ b/tasks/rspamd.yml
@@ -1,0 +1,17 @@
+---
+# tasks file for rspamd
+- name: Ensure rspamd is installed
+  apt:
+    name: '{{ item }}'
+    state: 'present'
+    install_recommends: 'no'
+  with_items: rspamd_packages
+
+- name: Configure main rmilter config file
+  template:
+    src: 'etc/rmilter.conf.j2'
+    dest: '/etc/rmilter.conf'
+    owner: 'root'
+    group: '_rmilter'
+    mode: '0664'
+  notify: [ 'Restart rmilter' ]

--- a/templates/etc/postfix/main.cf/ansible.j2
+++ b/templates/etc/postfix/main.cf/ansible.j2
@@ -11,6 +11,7 @@
   'tls',
   'postscreen',
   'smtpd_restrictions',
+  'rspamd',
   'local_maincf' ] %}
 {% for part in postfix_tpl_maincf_parts %}
 {% include part + '.j2' %}

--- a/templates/etc/postfix/main.cf/rspamd.j2
+++ b/templates/etc/postfix/main.cf/rspamd.j2
@@ -1,0 +1,12 @@
+{% if 'rspamd' in postfix %}
+
+# rspamd
+{% if postfix_rmilter_bind == 'unix' %}
+smtpd_milters = unix:/run/rmilter/rmilter.sock 
+{% else %}
+smtpd_milters = inet:localhost:11000
+{% endif %}
+milter_protocol = 6
+milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
+milter_default_action = accept
+{% endif %}

--- a/templates/etc/rmilter.conf.j2
+++ b/templates/etc/rmilter.conf.j2
@@ -1,0 +1,268 @@
+# Sample config file for rmilter
+# $Id$
+#
+
+# .include - directive to include other config file
+#.include ./rmilter-grey.conf
+
+# pidfile - path to pid file
+# Default: pidfile = /var/run/rmilter.pid
+
+pidfile = /var/run/rmilter/rmilter.pid;
+
+
+clamav {
+	# servers - clamav socket definitions in format:
+	# /path/to/file
+	# host[:port]
+	# sockets are separated by ','
+	# Default: empty
+	#servers = localhost;
+	# connect_timeout - timeout in miliseconds for connecting to clamav
+	# Default: 1s
+	connect_timeout = 1s;
+
+	# port_timeout - timeout in miliseconds for waiting for clamav port response
+	# Default: 4s
+	port_timeout = 4s;
+
+	# results_timeout - timeout in miliseconds for waiting for clamav response
+	# Default: 20s
+	results_timeout = 20s;
+
+	# error_time - time in seconds during which we are counting errors
+	# Default: 10
+	error_time = 10;
+
+	# dead_time - time in seconds during which we are thinking that server is down
+	# Default: 300
+	dead_time = 300;
+
+	# maxerrors - maximum number of errors that can occur during error_time to make us thinking that 
+	# this upstream is dead
+	# Default: 10
+	maxerrors = 10;
+};
+
+spamd {
+	# servers - spamd socket definitions in format:
+	# /path/to/file
+	# host[:port]
+	# sockets are separated by ','
+	# is server name is prefixed with r: it is rspamd server
+	# Default: empty
+	servers = r:localhost:11333;
+
+	# also_check - extra spamd servers to check
+	#also_check = r:spam.example.com;
+
+	# diff_dir - path where to write messages that have different results from main and extra checks
+	#diff_dir = /var/run/rmilter/diffmsg;
+
+	# connect_timeout - timeout in milliseconds for connecting to spamd
+	# Default: 1s
+	connect_timeout = 1s;
+
+	# results_timeout - timeout in milliseconds for waiting for spamd response
+	# Default: 20s
+	results_timeout = 20s;
+
+	# error_time - time in seconds during which we are counting errors
+	# Default: 10
+	error_time = 10;
+
+	# dead_time - time in seconds during which we are thinking that server is down
+	# Default: 300
+	dead_time = 300;
+
+	# maxerrors - maximum number of errors that can occur during error_time to make us thinking that 
+	# this upstream is dead
+	# Default: 10
+	maxerrors = 10;
+
+	# reject_message - reject message for spam
+	# Default: "Spam message rejected; If this is not spam contact abuse"
+	reject_message = "Spam message rejected; If this is not spam contact abuse";
+
+	# whitelist - list of ips or nets that should be not checked with spamd
+	# Default: empty
+	whitelist = 127.0.0.1/32, 192.168.0.0/16;
+
+	# rspamd_metric - metric for using with rspamd
+	# Default: "default"
+	rspamd_metric = "default";
+};
+
+memcached {
+	# servers_grey - memcached servers for greylisting in format:
+	# host[:port][, host[:port]]
+	# It is possible to make memcached mirroring, its syntax is {server1, server2}
+	servers_grey = localhost:11211;
+
+	# servers_white - memcached servers for whitelisting in format similar to that is used
+	# in servers_grey
+	# servers_white = {localhost, mcgi12.example.com}, mcgi18.example.com:11211;
+	
+	# servers_limits - memcached servers used for limits storing, can not be mirrored
+	servers_limits = localhost;
+
+	# servers_id - memcached servers used for message id storing, can not be mirrored
+	servers_id = localhost;
+
+	# id_prefix - prefix for extracting message ids from memcached
+	# Default: empty (no prefix is prepended to key)
+	id_prefix = "message_id.";
+	
+	# grey_prefix - prefix for extracting greylisted records from memcached
+	# Default: empty (no prefix is prepended to key)
+	grey_prefix = "grey.";
+
+	# id_prefix - prefix for extracting whitelisted records from memcached
+	# Default: empty (no prefix is prepended to key)
+	white_prefix = "white.";
+
+	# connect_timeout - timeout in miliseconds for waiting for memcached
+	# Default: 1s
+	connect_timeout = 1s;
+
+	# error_time - time in seconds during which we are counting errors
+	# Default: 10
+	error_time = 10;
+
+	# dead_time - time in seconds during which we are thinking that server is down
+	# Default: 300
+	dead_time = 300;
+
+	# maxerrors - maximum number of errors that can occur during error_time to make us thinking that 
+	# this upstream is dead
+	# Default: 10
+	maxerrors = 10;
+
+	# protocol - protocol that is using for connecting to memcached (tcp or udp)
+	# Default: udp
+	protocol = tcp;
+};
+
+# bind_socket - socket credits for local bind:
+# unix:/path/to/file - bind to local socket
+# inet:port@host - bind to inet socket
+# Default: bind_socket = unix:/var/tmp/rmilter.sock;
+
+{% if postfix_rmilter_bind == 'unix' %}
+bind_socket = unix:/run/rmilter/rmilter.sock;
+{% else %}
+bind_socket = inet:11000@localhost;
+{% endif %}
+
+# tempdir - path to directory that contains temporary files
+# Default: $TMPDIR
+
+tempdir = /tmp;
+
+# max_size - maximum size of scanned mail with clamav and dcc
+# Default: 0 (no limit)
+max_size = 10M;
+
+# spf_domains - path to file that contains hash of spf domains
+# Default: empty
+
+#spf_domains = example.com;
+
+# use_dcc - whether use or not dcc system
+# Default: no
+
+use_dcc = no;
+
+# rule definition:
+# rule {
+#	accept|discard|reject|tempfail|quarantine "[message]"; <- action definition
+#	[not] connect <regexp> <regexp>; <- conditions
+#	helo <regexp>;
+#	envfrom <regexp>;
+#	envrcpt <regexp>;
+#	header <regexp> <regexp>;
+#	body <regexp>;
+# };
+
+# limits section
+limits {
+	# Whitelisted ip or networks
+	# limit_whitelist = 194.67.45.4/32;
+	# Whitelisted recipients
+	limit_whitelist_rcpt =  postmaster, mailer-daemon;
+	# Addrs for bounce checks
+	limit_bounce_addrs = postmaster, mailer-daemon, symantec_antivirus_for_smtp_gateways, <>, null, fetchmail-daemon;
+	# Limit for bounce mail
+	limit_bounce_to = 5:0.000277778;
+	# Limit for bounce mail per one source ip
+	limit_bounce_to_ip = 5:0.000277778;
+	# Limit for all mail per recipient
+	limit_to = 20:0.016666667;
+	# Limit for all mail per one source ip
+	limit_to_ip = 30:0.025;
+	# Limit for all mail per one source ip and from address
+	limit_to_ip_from = 100:0.033333333;
+};
+
+beanstalk {
+	# List of beanstalk servers, random selected
+	#servers = bot01.example.com:3132;
+	
+	# Address of server to which rmilter should send all messages copies
+	#copy_server = somehost:13333;
+	
+	# Address of server to which rmilter should send spam messages copies
+	#spam_server = otherhost:13333;
+	
+	# Beanstalk protocol
+	protocol = tcp;
+	# Time to live for task in seconds
+	lifetime = 172800;
+	# Regexp that define for which messages we should put the whole message to beanstalk
+	# now only In-Reply-To headers are checked
+	id_regexp = "/^SomeID.*$/";
+	# Flags for sending beanstalk copies
+	send_beanstalk_headers = yes;
+	send_beanstalk_copy = yes;
+	send_beanstalk_spam = yes;
+};
+
+greylisting {
+	timeout = 300s;
+	expire = 3d;
+	whitelist = 127.0.0.1, 
+				192.168.1.1,
+				192.168.2.0/24;
+	awl_enable = yes;
+	awl_pool = 10M;
+	awl_hits = 10;
+	awl_ttl = 3600s;
+};
+
+dkim {
+	# Sample for dkim specific keys
+	# domain {
+	#   key = /etc/dkim/dkim_example.key;
+	#   domain = "example.com";
+	#	selector = "dkim";
+	# };
+	# domain {
+	#   key = /etc/dkim/dkim_test.key;
+	#   domain = "test.com";
+	#	selector = "dkim";
+	# };
+	# Universal selector, keys will be checked for pattern /etc/dkim/<domain>.<selector>.key
+    domain {
+		key = /etc/dkim;
+		domain = "*";
+		selector = "dkim";
+	};
+    header_canon = relaxed;
+    body_canon = relaxed;
+    sign_alg = sha256;
+};
+
+
+# Order of checks at EOM:
+# 
+# SPF -> DCC -> CLAMAV


### PR DESCRIPTION
Rspamd called by milter protocol is a lightweight solution for spam filtering with a minimum of configurations. This PR add an option to include these softwares.
