### PR TITLE
Fix "unexpected type error" if `postfix` is set to empty, true or false.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ postfix: [ 'null' ]
 # List of active Postfix capabilities. By default Postfix is configured with
 # local mail disabled, all mail is sent to a local MX server configured in DNS.
 # See :ref:`postfix_capabilities` for more details.
-postfix_capabilities: '{{ postfix }}'
+postfix_capabilities: '{{ postfix | d([], true) }}'
 
 
 # .. envvar:: postfix_packages


### PR DESCRIPTION
In this case `postfix_capabilities` are not iterable and thus
calculating `postfix_ferm_dependent_rules` did fail.