### PR TITLE
Add option to modify sasl authentication mechanism

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -380,6 +380,14 @@ postfix_smtpd_conf: |
   mech_list: PLAIN LOGIN
 
 
+# .. envvar:: postfix_saslauthd_mechanisms
+#
+# Configuration parameters passed to the :program:`saslauthd` daemon. Which
+# authentication mechanisms should saslauthd use. See :manpage:`saslauthd(8)`
+# for more details.
+postfix_saslauthd_mechanisms: 'pam'
+
+
 # .. envvar:: postfix_saslauthd_options
 #
 # Configuration parameters passed to the :program:`saslauthd` daemon. Path to

--- a/templates/etc/default/saslauthd-smtpd.j2
+++ b/templates/etc/default/saslauthd-smtpd.j2
@@ -30,7 +30,7 @@ NAME="saslauthd-smtpd"
 # for more information.
 #
 # Example: MECHANISMS="pam" #}
-MECHANISMS="pam"
+MECHANISMS="{{ postfix_saslauthd_mechanisms }}"
 
 # Additional options for this mechanism. (default: none)
 # See the saslauthd man page for information about mech-specific options.


### PR DESCRIPTION
I'm working on building a simple relay using a sasldb, but can't change the authentication mechanism to use it.