### PR TITLE
Ensure that main.cf includes are separated by a whitespace

### DIFF
--- a/templates/etc/postfix/main.cf/ansible.j2
+++ b/templates/etc/postfix/main.cf/ansible.j2
@@ -13,5 +13,9 @@
   'smtpd_restrictions',
   'local_maincf' ] %}
 {% for part in postfix_tpl_maincf_parts %}
-{% include part + '.j2' %}
+
+# Start {{ part }}
+{% include part + '.j2' %} {# here is a tactical comment
+to make sure we have a whitespace following the inclusion
+to avoid https://github.com/debops/ansible-postfix/issues/80 #}
 {% endfor %}


### PR DESCRIPTION
Includes files may not have a trailing whitespace which
causes the next included template to be put on the same line.
This will lead to broken configuration entries.

Addresses https://github.com/debops/ansible-postfix/issues/80