### PR TITLE
sasl: Only install cyrus packages if sasl type is cyrus

### DIFF
--- a/tasks/auth_sasl.yml
+++ b/tasks/auth_sasl.yml
@@ -6,6 +6,7 @@
     state: 'present'
     install_recommends: False
   with_items: [ 'sasl2-bin', 'libsasl2-modules' ]
+  when: postfix_smtpd_sasl_type == 'cyrus'
 
 - name: Add Postfix user to sasl group
   user:
@@ -22,6 +23,7 @@
     owner: 'root'
     group: 'sasl'
     mode: '0640'
+  when: postfix_smtpd_sasl_type == 'cyrus'
 
 - name: Configure saslauthd service
   template:
@@ -30,11 +32,13 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  when: postfix_smtpd_sasl_type == 'cyrus'
   notify: [ 'Restart saslauthd' ]
   register: postfix_register_configure_saslauthd
 
 - name: Override attributes for saslauthd socket in Postfix chroot
   shell: dpkg-statoverride --add root sasl 710 /var/spool/postfix/var/run/saslauthd || true
-  when: postfix_register_configure_saslauthd is defined and
+  when: postfix_smtpd_sasl_type == 'cyrus' and
+        postfix_register_configure_saslauthd is defined and
         postfix_register_configure_saslauthd.changed
 


### PR DESCRIPTION
When using dovecot as SASL provider, we don't need to install
cyrus.  So cyrus dependent tasks are skipped.