### PR TITLE
DRUPSIBLE-284 Fix Configure Cyrus SASL Authentication

### DIFF
--- a/tasks/auth_sasl.yml
+++ b/tasks/auth_sasl.yml
@@ -16,6 +16,11 @@
     createhome: False
   notify: [ 'Check postfix and restart' ]
 
+- name: Make sure /etc/postfix/sasl exists
+  file:
+    path: '/etc/postfix/sasl'
+    state: 'directory'
+
 - name: Configure Cyrus SASL Authentication
   template:
     src: 'etc/postfix/sasl/smtpd.conf.j2'


### PR DESCRIPTION
I got this error today

```
TASK [debops.postfix : Configure Cyrus SASL Authentication] *********************************************************************************
fatal: [stage.mariasoler.design]: FAILED! => {"changed": true, "failed": true, "msg": "Destination directory /etc/postfix/sasl does not exist"}
	to retry, use: --limit @/vagrant/ansible/playbooks/config.retry
```

This PR fixes it. Cheers.